### PR TITLE
locked to 0.9.0, until we have a stac-api-spec release

### DIFF
--- a/STAC-api.html
+++ b/STAC-api.html
@@ -10,7 +10,7 @@
    <div id="content"></div>
    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
    <script type="text/javascript">
-     Redoc.init('https://raw.githubusercontent.com/radiantearth/stac-spec/master/api-spec/STAC.yaml', {
+     Redoc.init('https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/api-spec/STAC.yaml', {
        expandResponses:"200,201,202,203,204",
        pathInMiddlePanel: true,
        hideDownloadButton: true

--- a/STAC-ext-api.html
+++ b/STAC-ext-api.html
@@ -10,7 +10,7 @@
    <div id="content"></div>
    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
    <script type="text/javascript">
-     Redoc.init('https://raw.githubusercontent.com/radiantearth/stac-spec/master/api-spec/STAC-extensions.yaml', {
+     Redoc.init('https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/api-spec/STAC-extensions.yaml', {
        expandResponses:"200,201,202,203,204",
        pathInMiddlePanel: true,
        hideDownloadButton: true


### PR DESCRIPTION
So that things don't break when we release 1.0-beta.1