### PR TITLE
Fix links to localhost

### DIFF
--- a/content/get-involved/data-providers.js
+++ b/content/get-involved/data-providers.js
@@ -37,7 +37,7 @@ const closingContent = {
     en: 
 `## STAC Community
     
-If you'd like to get involved with the STAC community, the [How to Help](http://localhost:8080/en/get-involved/) page is a good place to learn about our active needs. If you're not sure where to begin, say hi in the [STAC Gitter chat](https://gitter.im/SpatioTemporal-Asset-Catalog/Lobby), and you'll likely find someone who will be more than happy to point you in the right direction.`
+If you'd like to get involved with the STAC community, the [How to Help](https://stacspec.org/en/get-involved/) page is a good place to learn about our active needs. If you're not sure where to begin, say hi in the [STAC Gitter chat](https://gitter.im/SpatioTemporal-Asset-Catalog/Lobby), and you'll likely find someone who will be more than happy to point you in the right direction.`
 }
 
 module.exports = {

--- a/content/get-involved/developers.js
+++ b/content/get-involved/developers.js
@@ -55,7 +55,7 @@ const closingContent = {
     en: 
 `## STAC Community
     
-If you'd like to get involved with the STAC community, the [How to Help](http://localhost:8080/en/get-involved/) page is a good place to learn about our active needs. If you're not sure where to begin, say hi in the [STAC Gitter chat](https://gitter.im/SpatioTemporal-Asset-Catalog/Lobby), and you'll likely find someone who will be more than happy to point you in the right direction.`
+If you'd like to get involved with the STAC community, the [How to Help](https://stacspec.org/en/get-involved/) page is a good place to learn about our active needs. If you're not sure where to begin, say hi in the [STAC Gitter chat](https://gitter.im/SpatioTemporal-Asset-Catalog/Lobby), and you'll likely find someone who will be more than happy to point you in the right direction.`
 }
 
 module.exports = {


### PR DESCRIPTION
Fixes the URLS for "How to Help" links on the Developers and Data Providers pages that point to `localhost`.

Resolves #65 