### PR TITLE
Fix meta text for tutorials

### DIFF
--- a/content/tutorials.js
+++ b/content/tutorials.js
@@ -4,7 +4,7 @@ module.exports = {
             en: 'STAC Tutorials',
         },
         description: {
-            en: 'Here you can find Lorem ipsum dolor sit amet consectetur adipisicing elit.'
+            en: 'Here you can find our library of tutorials for learning all about STAC.'
         }
     },
 


### PR DESCRIPTION
Discovered when the tutorial link was posted to our Slack:

![Screenshot 2023-04-20 at 6 46 55 AM](https://user-images.githubusercontent.com/58314/233370344-9fd416fe-35b3-4046-8c91-34e5c4e1b34f.png)
