### PR TITLE
fixing R tutorial titles

### DIFF
--- a/app/tutorials/r/1-download-data-using-r/1-download-data-using-r.en.md
+++ b/app/tutorials/r/1-download-data-using-r/1-download-data-using-r.en.md
@@ -1,5 +1,5 @@
 ---
-title: Download data using R
+title: Download data from a STAC API using R, rstac, and GDAL
 description: How to download data using R
 ---
 

--- a/app/tutorials/r/2-using-rstac-and-cql2-to-query-stac-api/2-using-rstac-and-cql2-to-query-stac-api.en.md
+++ b/app/tutorials/r/2-using-rstac-and-cql2-to-query-stac-api/2-using-rstac-and-cql2-to-query-stac-api.en.md
@@ -1,5 +1,5 @@
 ---
-title: Download data from a STAC API using R, rstac, and GDAL
+title: Using rstac and CQL2 to query STAC APIs
 description: How to download data using R
 ---
 


### PR DESCRIPTION
I just noticed the titles were incorrect for the R tutorials. I have fixed them. 